### PR TITLE
Move all allocations to closures

### DIFF
--- a/mp3_test.go
+++ b/mp3_test.go
@@ -96,11 +96,15 @@ func TestMp3(t *testing.T) {
 		pumpAllocator := mp3.Source{Reader: inFile}
 
 		outFile, _ := os.Create(fmt.Sprintf("%s-%d-%s.mp3", out, i, test.vbr))
+		var quality *mp3.Quality
+		if test.useQuality {
+			quality = mp3.EncodingQuality(test.quality)
+		}
 		sinkAllocator := mp3.Sink{
 			Writer:          outFile,
 			ChannelMode:     test.channelMode,
 			BitRateMode:     test.vbr,
-			EncodingQuality: mp3.EncodingQuality(test.quality),
+			EncodingQuality: quality,
 		}
 
 		line, _ := pipe.Routing{

--- a/mp3_test.go
+++ b/mp3_test.go
@@ -93,7 +93,7 @@ func TestMp3(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("Test: %d of %d VBR: %d\n", i+1, len(tests), test.vbr)
 		inFile, _ := os.Open(test.inFile)
-		pumpAllocator := mp3.Pump{Reader: inFile}
+		pumpAllocator := mp3.Source{Reader: inFile}
 
 		outFile, _ := os.Create(fmt.Sprintf("%s-%d-%s.mp3", out, i, test.vbr))
 		sinkAllocator := &mp3.Sink{

--- a/mp3_test.go
+++ b/mp3_test.go
@@ -96,13 +96,11 @@ func TestMp3(t *testing.T) {
 		pumpAllocator := mp3.Source{Reader: inFile}
 
 		outFile, _ := os.Create(fmt.Sprintf("%s-%d-%s.mp3", out, i, test.vbr))
-		sinkAllocator := &mp3.Sink{
-			Writer:      outFile,
-			ChannelMode: test.channelMode,
-			BitRateMode: test.vbr,
-		}
-		if test.useQuality {
-			sinkAllocator.SetQuality(test.quality)
+		sinkAllocator := mp3.Sink{
+			Writer:          outFile,
+			ChannelMode:     test.channelMode,
+			BitRateMode:     test.vbr,
+			EncodingQuality: mp3.EncodingQuality(test.quality),
 		}
 
 		line, _ := pipe.Routing{


### PR DESCRIPTION
Move all references from source/sink structs to closures.